### PR TITLE
allow caller to select behavior for invalid xml characters

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,13 @@ user> (xml/emit-sexp-str [:root {:xmlns:xsi "http://www.w3.org/2001/XMLSchema-in
 "<?xml version=\"1.0\" encoding=\"UTF-8\"?><root xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"><child xsi:nil=\"true\"></child></root>"
 ```
 
+With `:invalid-char-behavior` option. Supports `:fail`, `:replace-all`, and `replace-whitespace`. If no option is supplied, defaults to Woodstox failing handler.
+
+```clojure
+user> (xml/emit-sexp-str [:root "value1\u001Cvalue2"] :invalid-char-behavior :replace-whitespace)
+"<?xml version='1.0' encoding='UTF-8'?><root>value1 value2</root>"
+```
+
 ## TODO
 
 - [ ] use empty elements when values are nil [:elem {} nil] -> <elem />

--- a/project.clj
+++ b/project.clj
@@ -6,7 +6,7 @@
   :dependencies [[org.clojure/clojure "1.9.0"]
                  [com.fasterxml.woodstox/woodstox-core "5.1.0"]
                  [org.clojure/data.xml "0.0.8"]]
-  :profiles {:dev {:dependencies [[midje "1.9.1"]
+  :profiles {:dev {:dependencies [[midje "1.10.10"]
                                   [perforate "0.3.4"]]
                    :plugins [[lein-midje "3.1.1"]
                              [perforate "0.3.4"]]}
@@ -14,4 +14,6 @@
   :perforate {:environments [{:name :current
                               :profiles [:dev :bench]
                               :namespaces [xml-writer.room-avail]}]}
+  :aot [xml-writer.replace-invalid-whitespace]
+  :java-source-paths ["src"]
   :repositories [["sonatype-oss-public" "https://oss.sonatype.org/content/groups/public/"]])

--- a/src/xml_writer/replace_invalid_whitespace.clj
+++ b/src/xml_writer/replace_invalid_whitespace.clj
@@ -1,0 +1,21 @@
+(ns xml-writer.replace-invalid-whitespace
+  (:import (com.ctc.wstx.api InvalidCharHandler$ReplacingHandler)
+           (com.ctc.wstx.api InvalidCharHandler$FailingHandler))
+  (:gen-class
+   :name com.github.bpoweski.ReplaceInvalidWhitespace
+   :implements [com.ctc.wstx.api.InvalidCharHandler]))
+
+(defn invalid-whitespace-char?
+  "to be used in cases where invalid whitespace characters should be replaced, but the user 
+  would like to throw an exception for all other conditions of FailingHandler. see:
+  https://github.com/FasterXML/woodstox/blob/7aa010e672d1bb7d81b4650a71705cb2bb524f98/src/main/java/com/ctc/wstx/api/InvalidCharHandler.java#L54"
+  [c]
+  (or (and (< c (int \space)) (not= c 0))
+      (and (>= c 0x7F)
+           (<= c 0x9F))))
+
+(let [failing-handler (InvalidCharHandler$FailingHandler/getInstance)]
+  (defn -convertInvalidChar [this c]
+    (if (invalid-whitespace-char? c)
+      (char \space)
+      (.convertInvalidChar failing-handler c))))

--- a/test/xml_writer/core_test.clj
+++ b/test/xml_writer/core_test.clj
@@ -29,3 +29,13 @@
 
 (facts "emitting object values"
   [:root 20.0M] => compatible?)
+
+(facts "emitting xml string despite invalid input characters"
+  (emit-sexp-str
+   [:root [:child {:attribute "value"} "Some text\u0000more text"]]
+   :invalid-char-behavior :replace-all :replacement-char (char \;)) =>
+  "<?xml version='1.0' encoding='UTF-8'?><root><child attribute=\"value\">Some text;more text</child></root>"
+  (emit-sexp-str
+   [:root [:child {:attribute "value"} "Some text\u0001more text"]]
+   :invalid-char-behavior :replace-whitespace) =>
+  "<?xml version='1.0' encoding='UTF-8'?><root><child attribute=\"value\">Some text more text</child></root>")


### PR DESCRIPTION
The default woodstox behavior is to throw an exception upon encountering an invalid xml character. However, alternate behavior can be set via the `P_OUTPUT_INVALID_CHAR_HANDLER` property. 

This PR exposes a few common options to that property via keywords that can be passed to `emit-sexp-str`. 